### PR TITLE
fix bugs; DRY up code; add start, depth args

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,29 @@ Ruby gem to extend Hash and Array with filters for blank, empty, and nil values.
 
 Build status: [![CircleCI](https://circleci.com/gh/aks/blank_empty_nil_filters/tree/master.svg?style=svg)](https://circleci.com/gh/aks/blank_empty_nil_filters/tree/master)
 
-This module creates new methods to be prepended to the Array, Hash, String,
-and Object classes to implement recursive filters for _blank_, _empty_, and
-nil values.
+This module creates new methods to be prepended to the Array, Hash,
+String, and Object classes to implement recursive filters for _blank_,
+_empty_, and nil values.
 
-Note: `ActiveSupport` provides _some_ of these methods, but in general is a *much* larger body
-of code.  This module are only those methods related to "blank", "empty" or nil. Also,
-`ActiveSupport` uses `Regexp` `match` to determine blankness, while this code uses a
-non-destructive `strip`, which is both faster and less sensitive to non-UTF8 string error
-conditions.
+The methods can select or reject values which are blank _(whitespace)_, 
+empty _(zero length)_, or nil, and do so recursively.
 
-In general an _empty_ value has zero length, and a _blank_ value is either empty or has
-all blank values (e.g., `to_s.strip.length.zero?`)
+The default behavior is to filter recursively, without limit.
+However, optional arguments may be applied to any filter method to
+indicate the _start_ level and the _depth_ to which filtering should
+be done.  This is useful if, say, a hash needs to retain its top-level
+keys, regardless of whether or not its values are empty, but deeper
+level hashes can be completely removed if they are empty.
+
+Note: `ActiveSupport` provides _some_ of these methods, but in general
+is a *much* larger body of code.  This module are only those methods
+related to "blank", "empty" or nil. Also, `ActiveSupport` uses
+`Regexp` `match` to determine blankness, while this code uses a
+non-destructive `strip`, which is both faster and less sensitive to
+non-UTF8 string error conditions.
+
+In general an _empty_ value has zero length, and a _blank_ value is either 
+empty or has all blank values (e.g., `to_s.strip.length.zero?`)
 
 In the descriptions below, `aoh` is an `Array` or `Hash` object.
 
@@ -67,6 +78,7 @@ hash.nil_value_keys         # keys from nil values
 ```
 
 All of the `no_*` methods have aliases of `reject_*`.  For example, `reject_empty_values`.
+All of the `only_*` methods have aliases of `select_*`; eg: `select_nil_values`.
 Some folks prefer the shorter names, some prefer the longer ones.  Take your pick.
 
 ```ruby
@@ -74,6 +86,19 @@ aoh.reject_empty_values     # aoh.no_empty_values
 aoh.reject_blank_values     # aoh.no_blank_values
 aoh.reject_nil_values       # aoh.no_nil_values
 ```
+
+Any of the above methods can be provided optional arguments of _start_ and _depth_
+to indicate levels at which filter _(selecting or rejecting)_ should start and 
+stop.
+
+```ruby
+aoh.no_empty_values(1)      # no empty items at level 1 or higher; leave level 0 alone
+aoh.no_blank_values(1)      # no blank items at level 1 or higher; leave level 0 alone
+aoh.no_nil_values(1, 4)     # no nil items at level 1 until level 4; level level 0 alone
+```
+
+Note that it is important to use a `depth`  value to prevent infinite loops when there 
+are recursive data structures.
 
 All of the above methods are wrappers around two general purpose methods:
 

--- a/lib/blank_empty_nil_filters/version.rb
+++ b/lib/blank_empty_nil_filters/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BlankEmptyNilFilters
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/spec/blank_empty_nil_filters_spec.rb
+++ b/spec/blank_empty_nil_filters_spec.rb
@@ -38,11 +38,22 @@ RSpec.describe BlankEmptyNilFilters do
   end
 
   shared_examples_for 'select_values' do |test_data, filter, result_index, action, test_kind|
-    describe "#reject_values(:#{filter})" do
+    describe "#select_values(:#{filter})" do
       test_data.each do |data|
         desc, test_datum, test_result = data.values_at(DESC_INDEX, DATA_INDEX, result_index)
         it "#{action} #{test_kind} #{desc}" do
           expect(test_datum.select_values(filter)).to eq test_result
+        end
+      end
+    end
+  end
+
+  shared_examples_for 'key_filters' do |test_data, method, result_index, action, test_kind|
+    describe "#{method}" do
+      test_data.each do |data|
+        desc, test_datum, test_result = data.values_at(DESC_INDEX, DATA_INDEX, result_index)
+        it "#{action} #{test_kind} #{desc}" do
+          expect(test_datum.send(method)).to match_array(test_result.keys)
         end
       end
     end
@@ -65,7 +76,7 @@ RSpec.describe BlankEmptyNilFilters do
   end
 
   describe "ArrayFilters" do
-    context 'reject_* methods' do
+    context 'reject and select methods' do
       test_array_data =
         [
           [
@@ -110,9 +121,17 @@ RSpec.describe BlankEmptyNilFilters do
       it_behaves_like 'reject_filters', test_array_data, :no_blank_values,   NON_BLANK_RESULT_INDEX,  'rejects', 'blank or nil'
       it_behaves_like 'reject_filters', test_array_data, :no_nil_values,     NON_NIL_RESULT_INDEX,    'rejects', 'nil'
 
+      it_behaves_like 'reject_filters', test_array_data, :reject_empty_values, NON_EMPTY_RESULT_INDEX, 'rejects', 'empty or nil'
+      it_behaves_like 'reject_filters', test_array_data, :reject_blank_values, NON_BLANK_RESULT_INDEX, 'rejects', 'blank or nil'
+      it_behaves_like 'reject_filters', test_array_data, :reject_nil_values,   NON_NIL_RESULT_INDEX,   'rejects', 'nil'
+
       it_behaves_like 'reject_filters', test_array_data, :only_empty_values, ONLY_EMPTY_RESULT_INDEX, 'selects', 'empty or nil'
       it_behaves_like 'reject_filters', test_array_data, :only_blank_values, ONLY_BLANK_RESULT_INDEX, 'selects', 'blank or nil'
       it_behaves_like 'reject_filters', test_array_data, :only_nil_values,   ONLY_NIL_RESULT_INDEX,   'selects', 'nil'
+
+      it_behaves_like 'reject_filters', test_array_data, :select_empty_values, ONLY_EMPTY_RESULT_INDEX, 'selects', 'empty or nil'
+      it_behaves_like 'reject_filters', test_array_data, :select_blank_values, ONLY_BLANK_RESULT_INDEX, 'selects', 'blank or nil'
+      it_behaves_like 'reject_filters', test_array_data, :select_nil_values,   ONLY_NIL_RESULT_INDEX,   'selects', 'nil'
 
       it_behaves_like 'reject_values',  test_array_data, :is_empty?,         NON_EMPTY_RESULT_INDEX,  'rejects', 'empty or nil'
       it_behaves_like 'reject_values',  test_array_data, :is_blank?,         NON_BLANK_RESULT_INDEX,  'rejects', 'blank or nil'
@@ -146,7 +165,7 @@ RSpec.describe BlankEmptyNilFilters do
   end
 
   describe "HashFilters" do
-    context 'reject_* methods' do
+    context 'reject and select methods' do
       test_hash_data =
         [
           [
@@ -202,6 +221,14 @@ RSpec.describe BlankEmptyNilFilters do
       it_behaves_like 'select_values',  test_hash_data, :is_empty?,           ONLY_EMPTY_RESULT_INDEX, 'selects', 'empty or nil'
       it_behaves_like 'select_values',  test_hash_data, :is_blank?,           ONLY_BLANK_RESULT_INDEX, 'selects', 'blank or nil'
       it_behaves_like 'select_values',  test_hash_data, :is_nil?,             ONLY_NIL_RESULT_INDEX,   'selects', 'nil'
+
+      it_behaves_like 'key_filters',    test_hash_data, :blank_value_keys,    ONLY_BLANK_RESULT_INDEX, 'selects', 'blank or nil'
+      it_behaves_like 'key_filters',    test_hash_data, :empty_value_keys,    ONLY_EMPTY_RESULT_INDEX, 'selects', 'empty or nil'
+      it_behaves_like 'key_filters',    test_hash_data, :nil_value_keys,      ONLY_NIL_RESULT_INDEX,   'selects', 'nil'
+
+      it_behaves_like 'key_filters',    test_hash_data, :non_blank_value_keys, NON_BLANK_RESULT_INDEX, 'rejects', 'blank or nil'
+      it_behaves_like 'key_filters',    test_hash_data, :non_empty_value_keys, NON_EMPTY_RESULT_INDEX, 'rejects', 'empty or nil'
+      it_behaves_like 'key_filters',    test_hash_data, :non_nil_value_keys,   NON_NIL_RESULT_INDEX,   'rejects', 'nil'
     end
 
     context 'boolean methods on hashes' do


### PR DESCRIPTION
This PR:
- adds `start` and `depth` arguments to all the array and hash filter methods
- DRYs up the filtering code, using some common methods
- fixes two broken filters that were not covered in specs
- fixes the specs to cover the previous bugs

TBD: specs on the new args